### PR TITLE
getLogs with rpcMode: fix bug cannot get erc20 transfer log

### DIFF
--- a/libs/AssistedJsonRpcProvider.js
+++ b/libs/AssistedJsonRpcProvider.js
@@ -278,8 +278,10 @@ function getTopicsQuery(topics) {
  * @param items array
  */
 function trimTrailingNullItems (items) {
-  const endIndex = items.length - [...items].reverse().findIndex((i => i != null))
-  return items.slice(0, endIndex)
+  while (items[items.length-1] == null) {
+    items.pop();
+  }
+  return items
 }
 
 module.exports = AssistedJsonRpcProvider;

--- a/libs/AssistedJsonRpcProvider.js
+++ b/libs/AssistedJsonRpcProvider.js
@@ -142,12 +142,12 @@ class AssistedJsonRpcProvider extends Provider {
         for (let i = 0; i < maxLength; ++i) {
             const f = {
                 ...filter,
-                topics: [
+                topics: trimTrailingNullItems([
                     filter?.topics?.[0]?.[i],
                     filter?.topics?.[1]?.[i],
                     filter?.topics?.[2]?.[i],
                     filter?.topics?.[3]?.[i],
-                ].filter((topic) => topic !== undefined)
+                ])
             }
             if (f.topics.some(topic => topic != null)) {
                 filters.push(f)
@@ -271,6 +271,15 @@ function getTopicsQuery(topics) {
         }
     }
     return query
+}
+
+/**
+ *
+ * @param items array
+ */
+function trimTrailingNullItems (items) {
+  const endIndex = items.length - [...items].reverse().findIndex((i => i != null))
+  return items.slice(0, endIndex)
 }
 
 module.exports = AssistedJsonRpcProvider;

--- a/libs/AssistedJsonRpcProvider.js
+++ b/libs/AssistedJsonRpcProvider.js
@@ -147,7 +147,7 @@ class AssistedJsonRpcProvider extends Provider {
                     filter?.topics?.[1]?.[i],
                     filter?.topics?.[2]?.[i],
                     filter?.topics?.[3]?.[i],
-                ]
+                ].filter((topic) => topic !== undefined)
             }
             if (f.topics.some(topic => topic != null)) {
                 filters.push(f)


### PR DESCRIPTION
Fix bug cannot get logs by RPC in some case
e.g: get event with filter like this
```
filter = {
  topics: [
    [topics.DDL, null, null, null],
    [null, accTopic, null, null],
    [null, null, accTopic, null],
    [null, null, null, accTopic],
  ],
}
```
It same with 4 request getLogs
```
filter = { topics: [topics.DDL, null, null, null] }
filter = { topics: [null, accTopic, null, null] }
filter = { topics: [null, null, accTopic, null] }
filter = { topics: [null, null, null, accTopic] }
```

ERC20 transfer event has interface
```
event Transfer(address indexed from, address indexed to, uint value);
```

If get event with topic `[null, acc, null, null]` will receive empty array, because erc20 transfer event has 3 topics

#Solution:
pass `topics = [null, acc, null, undefined]` instead of  `[null, acc, null, null]` and remove undefined value in topics

Now event filter like this:
```
filter = {
  topics: [
    [topics.DDL, null, null, null],
    [undefined, accTopic, null, null],
    [undefined, undefined, accTopic, null],
    [undefined, undefined, undefined, accTopic],
  ],
}
```