### PR TITLE
add a new config: etherscanConfig.singleRequest #2

### DIFF
--- a/doc/example.md
+++ b/doc/example.md
@@ -13,7 +13,7 @@ const { AssistedJsonRpcProvider } = require('assisted-json-rpc-provider')
 //  * config.rangeThreshold {number}. Threshold range to know whether to use Log API or ethers.provider's getLogs. Default: 5000. 
 //  * config.rateLimitCount and config.rateLimitDuration {number}. Default: Rate-limit's Log API is 1 calls/5second
 //  * config.apiKeys {string[]}. Using api-key to improve rate-limit
-//
+//  * config.singleRequest {boolean}. If true, only return the results of the first request
 //  * return the customized ethers.Provider for getLogs with massive ranges
 
 const provider = new AssistedJsonRpcProvider(
@@ -24,7 +24,8 @@ const provider = new AssistedJsonRpcProvider(
         rangeThreshold: 1000,
         rateLimitCount: 1,
         rateLimitDuration: 5000,
-        apiKeys:['apikey']
+        apiKeys:['apikey'],
+        singleRequest: false
     }
 )
 ```

--- a/libs/AssistedJsonRpcProvider.js
+++ b/libs/AssistedJsonRpcProvider.js
@@ -14,6 +14,7 @@ const { standardizeStartConfiguration } = require('./validator');
  *  url: 'https://api.etherscan.io/api',
  *  maxResults: 1000,
  *  apiKeys: ['YourApiKeyToken'],
+ *  singleRequest: false
  * }
  */
 class AssistedJsonRpcProvider extends Provider {
@@ -223,7 +224,7 @@ class AssistedJsonRpcProvider extends Provider {
             }
             let logs = await this.search(url);
 
-            if (logs.length < this.etherscanConfig.maxResults) {
+            if (logs.length < this.etherscanConfig.maxResults || this.etherscanConfig.singleRequest) {
                 return result.concat(logs);
             }
             let maxLog = _.maxBy(logs, 'blockNumber')

--- a/libs/validator.js
+++ b/libs/validator.js
@@ -10,13 +10,15 @@ function standardizeStartConfiguration(config) {
         'rateLimitDuration',
         'url',
         'maxResults',
-        'apiKeys'
+        'apiKeys',
+        'singleRequest'
     ]
 
     _validateRangeThreshold(config.rangeThreshold)
     _validateRateLimitCount(config.rateLimitCount)
     _validateRateLimitDuration(config.rateLimitDuration)
     _validateMaxResult(config.maxResults)
+    _validateSingleRequest(config.singleRequest)
 
     const unknownProp = Object.keys(config).find(prop => !knownProps.includes(prop))
     if (unknownProp) {
@@ -27,7 +29,8 @@ function standardizeStartConfiguration(config) {
         maxResults: 1000,
         rateLimitCount: 1,
         rateLimitDuration: 5 * 1000,
-        apiKeys: []
+        apiKeys: [],
+        singleRequest: false
     }
     return Object.assign(defaultConfig, config)
 }
@@ -69,6 +72,16 @@ function _validateMaxResult(value){
 
     if (!Number.isInteger(value) || value < 1) {
         throw new Error('invalid configuration "maxResults"')
+    }
+}
+
+function _validateSingleRequest(value){
+    if (value == null) {
+        return
+    }
+
+    if (typeof value !== "boolean") {
+        throw new Error('invalid configuration "singleRequest"')
     }
 }
 


### PR DESCRIPTION
add a new config: etherscanConfig.singleRequest

this will disable the loop scanLogs, and only return the results of the first request